### PR TITLE
workerが2重にconfigureをしようとして刺さるのに対処

### DIFF
--- a/backend/penguin_judge/worker.py
+++ b/backend/penguin_judge/worker.py
@@ -1,16 +1,10 @@
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
-from typing import Callable, Dict
 
 import pika  # type: ignore
 
-from penguin_judge.models import configure, config as db_config
 from penguin_judge.mq import get_mq_conn_params
 from penguin_judge.run_container import run
-
-
-def configure_db(config: Dict[str, str], f: Callable) -> None:
-    f()
 
 
 def callback(
@@ -19,7 +13,7 @@ def callback(
         method: pika.spec.Basic.Return,
         properties: pika.spec.BasicProperties,
         body: bytes) -> None:
-    executor.submit(configure_db, db_config, partial(run, body))
+    executor.submit(run, body)
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 


### PR DESCRIPTION
試しにlocalでworkerを動かしてみたところ、デリートしている部分で刺さっていました。
既にconfigureはworker起動時になされているために、このconfigureは不要に思いますが、如何でしょうか。