### PR TITLE
すべてのテストケースを一つのコンテナで、かつ、言語のコンテナを用意

### DIFF
--- a/backend/local_test_scripts/add_testdata_to_db.py
+++ b/backend/local_test_scripts/add_testdata_to_db.py
@@ -34,11 +34,13 @@ def add_test_contest(s: scoped_session) -> None:
 def add_test_environment(s: scoped_session) -> None:
     test_environment = Environment()
     test_environment.id = 1
-    test_environment.name = 'test'
+    test_environment.name = 'C'
     test_environment.config = json.loads('{"language" : "C", \
                         "compile_script" : "gcc -o ./a.out main.c", \
                         "srcfile_name" : "main.c", "exec_binary" : "a.out", \
-                        "exec_script" : "./a.out"}')
+                        "exec_script" : "./a.out",\
+                        "compile_image_name" : "compile_container_c",\
+                        "judge_image_name" : "judge_container_c"}')
     s.add(test_environment)
 
 

--- a/backend/local_test_scripts/post_submit.sh
+++ b/backend/local_test_scripts/post_submit.sh
@@ -1,0 +1,5 @@
+curl localhost:5000/contests
+curl localhost:5000/contests/1
+#curl -X POST -H 'Content-Type:application/json' -d "{}" localhost:5000/contests/1/problems/1
+#curl -X POST -H 'Content-Type:application/json' -d "{\"code\":\"int main(){}\",\"environment_id\":\"1\"}" localhost:5000/contests/1/problems/1
+curl -X POST -H 'Content-Type:application/json' -d "{\"code\":\"#include<stdio.h>\n#include<unistd.h>\n int main(){ sleep(10); int a; scanf(\\\"%d\\\", &a); printf(\\\"%d\\\",a);}\",\"environment_id\":\"1\"}" localhost:5000/contests/1/problems/1

--- a/container/compile_container/c/Dockerfile
+++ b/container/compile_container/c/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu
+RUN ["apt", "update"]
+RUN ["apt", "install", "-y", "g++"]
+COPY /compile_scripts /compile_scripts
+WORKDIR /compile_scripts
+CMD ["sh", "/compile_scripts/compile.sh"]

--- a/container/compile_container/c/compile_scripts/compile.sh
+++ b/container/compile_container/c/compile_scripts/compile.sh
@@ -1,0 +1,1 @@
+timeout 30 g++ -O2 -o /judge/a.out /judge/main.c

--- a/container/compile_container/c/misc/make_container_image.sh
+++ b/container/compile_container/c/misc/make_container_image.sh
@@ -1,0 +1,1 @@
+sudo docker build -t "compile_container_c" $(dirname $0)/..

--- a/container/judge_container/c/Dockerfile
+++ b/container/judge_container/c/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu
+RUN ["apt", "update"]
+RUN ["apt", "install", "-y", "g++"]
+RUN ["apt", "install", "-y", "time"]
+COPY /judge_scripts /judge_scripts
+WORKDIR /judge_scripts

--- a/container/judge_container/c/judge_scripts/judge.sh
+++ b/container/judge_container/c/judge_scripts/judge.sh
@@ -1,0 +1,3 @@
+for input_file in `\find /judge/tests/ -name '*.in'`; do
+    (time --format="%e %S %U %P %K %x %C" timeout $1 /judge/a.out < ${input_file} > ${input_file%.*}.out) 2>${input_file%.*}.result
+done

--- a/container/judge_container/c/misc/make_container_image.sh
+++ b/container/judge_container/c/misc/make_container_image.sh
@@ -1,0 +1,1 @@
+sudo docker build -t "judge_container_c" $(dirname $0)/..


### PR DESCRIPTION
すべてのテストケースを一つのコンテナの中で処理するものです。  
IOをシリアライズして、agentをバイナリにした上でlibも極力非依存というのがとてもしんどそうだったので、とりあえず過去のfileIOの形式を取りました。  
後で変更しようと思います。  
とりあえずall testcase in one containerの雛形として投稿します。