### PR TITLE
backend: コンテスト開催中は自分以外の提出詳細にアクセスできないように修正

### DIFF
--- a/backend/penguin_judge/models.py
+++ b/backend/penguin_judge/models.py
@@ -165,6 +165,12 @@ class Submission(Base, _Exportable):
         Index('submissions_contest_problem_idx', contest_id, problem_id),
     )
 
+    def is_accessible(self, contest: Contest,
+                      user_info: Optional[dict]) -> bool:
+        if contest.is_finished() or (user_info and user_info['admin']):
+            return True
+        return self.user_id == (user_info['id'] if user_info else '')
+
 
 class JudgeResult(Base, _Exportable):
     __tablename__ = 'judge_results'

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -312,7 +312,9 @@ class TestAPI(unittest.TestCase):
         }, headers=self.admin_headers).json
         self.assertEqual([resp], app.get(
             '{}/submissions'.format(prefix), headers=self.admin_headers).json)
-        resp2 = app.get('{}/submissions/{}'.format(prefix, resp['id'])).json
+        app.get('{}/submissions/{}'.format(prefix, resp['id']), status=404)
+        resp2 = app.get('{}/submissions/{}'.format(prefix, resp['id']),
+                        headers=self.admin_headers).json
         self.assertEqual(resp2.pop('code'), code)
         self.assertEqual(resp, resp2)
 


### PR DESCRIPTION
* /contests/{contest_id}/submissions/{submission_id} に関して、チェックが漏れていた
* dictに対してgetattrしている箇所があったがdict型の場合は想定した挙動にならないので修正