### PR TITLE
Frontend: 提出後に提出一覧に、未ログイン時にログインページに遷移させる

### DIFF
--- a/frontend/src/views/contest-task.ts
+++ b/frontend/src/views/contest-task.ts
@@ -28,13 +28,17 @@ export class AppContestTaskElement extends LitElement {
       problem_id: session.task_id,
       code: code,
       environment_id: parseInt(env),
-    }).catch(e => {
+    }).then(s => {
+      router.navigate(router.generate('contest-submission', {
+        id: session.contest!.id,
+        submission_id: s.id,
+      }));
+    }, e => {
       if (e.status === 401) {
         alert("ログインが必要です");
         router.navigate('login');
       }
     });
-    router.navigate(`/contests/${session.contest.id}/submissions`, true);
   }
 
   render() {


### PR DESCRIPTION
- UXや多重提出防止のため、提出後に画面遷移を追加