### PR TITLE
frontend: 順位表が開けないとログイン画面にリダイレクトされる問題を修正

### DIFF
--- a/frontend/src/views/contest-standings.ts
+++ b/frontend/src/views/contest-standings.ts
@@ -32,7 +32,6 @@ export class PenguinJudgeContestStandings extends LitElement {
             this.requestUpdate();
         }).catch(err => {
             console.log(err);
-            router.navigate('login');
         })
 
         this.problems = session!.contest!.problems!.map((problem) => problem.id);


### PR DESCRIPTION
- fix #83 
- #82 もリダイレクトしないで統一できそう