### PR TITLE
backend: workerのmax_processes設定のデフォルト値を1からプロセス割当CPUコア数に変更

### DIFF
--- a/backend/penguin_judge/main.py
+++ b/backend/penguin_judge/main.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, Namespace
 from configparser import ConfigParser
+from os import sched_getaffinity
 from typing import Mapping
 
 from penguin_judge.models import configure, get_db_config
@@ -35,7 +36,9 @@ def start_worker(args: Namespace) -> None:
     config = _load_config(args, 'worker')
     configure(**config)
     configure_mq(**config)
-    max_processes = int(config.get('max_processes', '1'))
+    max_processes = int(config.get('max_processes', 0))
+    if max_processes <= 0:
+        max_processes = len(sched_getaffinity(0))
     worker_main(get_db_config(), max_processes)
 
 


### PR DESCRIPTION
設定が未指定または0以下の値が指定されていた際にデフォルト値が利用される

Fixed: #79 