### PR TITLE
Frontend: 提出一覧ページに暫定的にページネーションを追加

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -187,9 +187,9 @@ export class API {
     });
   }
 
-  static list_submissions(contest_id: string): Promise<Array<Submission>> {
+  static list_submissions(contest_id: string, page: number): Promise<Array<Submission>> {
     return API._fetch(
-      '/api/contests/' + encodeURIComponent(contest_id) + '/submissions');
+      '/api/contests/' + encodeURIComponent(contest_id) + '/submissions?page=' + page);
   }
 
   static get_submission(contest_id: string, submission_id: string): Promise<Submission> {
@@ -230,7 +230,7 @@ export class API {
   static create_contest(contest: Contest): Promise<Contest> {
     return API._fetch('/api/contests', {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(contest),
     });
   }
@@ -238,7 +238,7 @@ export class API {
   static update_contest(contest_id: string, patch: any): Promise<Contest> {
     return API._fetch('/api/contests/' + encodeURIComponent(contest_id), {
       method: 'PATCH',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
     });
   }
@@ -246,7 +246,7 @@ export class API {
   static create_problem(contest_id: string, problem: Problem): Promise<Problem> {
     return API._fetch('/api/contests/' + encodeURIComponent(contest_id) + '/problems', {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(problem),
     });
   }
@@ -254,7 +254,7 @@ export class API {
   static update_problem(contest_id: string, problem_id: string, patch: any): Promise<Problem> {
     return API._fetch('/api/contests/' + encodeURIComponent(contest_id) + '/problems/' + encodeURIComponent(problem_id), {
       method: 'PATCH',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
     });
   }
@@ -270,7 +270,7 @@ export class API {
   static upload_test_dataset(contest_id: string, problem_id: string, file: File): Promise<Array<string>> {
     return API._fetch('/api/contests/' + encodeURIComponent(contest_id) + '/problems/' + encodeURIComponent(problem_id) + '/tests', {
       method: 'PUT',
-      headers: {'Content-Type': 'application/zip'},
+      headers: { 'Content-Type': 'application/zip' },
       body: file,
     });
   }

--- a/frontend/src/views/contest-submission-results.ts
+++ b/frontend/src/views/contest-submission-results.ts
@@ -8,6 +8,8 @@ import { format_datetime_detail, getSubmittionStatusMark } from '../utils';
 export class PenguinJudgeContestSubmissionResults extends LitElement {
   subscription: Subscription | null = null;
   submissions: Submission[] = [];
+  page: number = 1;
+  contestId: string | null = null;
 
   constructor() {
     super();
@@ -19,12 +21,32 @@ export class PenguinJudgeContestSubmissionResults extends LitElement {
       // session.contest/session.environment_mapping経由でアクセスできる
       const s = session.contest;
       if (s) {
-        API.list_submissions(s.id).then((submissions) => {
+        this.contestId = s.id;
+        API.list_submissions(this.contestId, 1).then((submissions) => {
           this.submissions = submissions;
           this.requestUpdate();
         });
       }
     });
+  }
+
+  goToPage() {
+    API.list_submissions(this.contestId!, this.page).then(submissions => {
+      this.submissions = submissions;
+      this.requestUpdate();
+    });
+  }
+
+  goToPrev() {
+    if (this.page > 1) {
+      this.page--;
+      this.goToPage();
+    }
+  }
+
+  goToNext() {
+    this.page = this.page + 1;
+    this.goToPage();
   }
 
   disconnectedCallback() {
@@ -53,6 +75,11 @@ export class PenguinJudgeContestSubmissionResults extends LitElement {
         </tr>`;
     });
     return html`
+      <div id="pagenation">
+        <button @click="${this.goToPrev}">&lt;</button>
+        <span>${this.page}ページ目</span>
+        <button @click="${this.goToNext}">&gt;</button>
+      </div>
       <table>
         <thead><tr><td>提出日時</td><td>問題</td><td>ユーザ</td><td>言語</td><td>結果</td><td></td></tr></thead>
         <tbody>${nodes}</tbody>

--- a/frontend/src/views/contest-submission.ts
+++ b/frontend/src/views/contest-submission.ts
@@ -1,7 +1,7 @@
 import { customElement, LitElement, html, css } from 'lit-element';
 import { Subscription, zip } from 'rxjs';
-import { API, Submission } from '../api';
-import { session } from '../state';
+import { API, Submission, JudgeStatus } from '../api';
+import { router, session } from '../state';
 import { format_datetime_detail, getSubmittionStatusMark } from '../utils';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 const hljs = require('highlight.js');
@@ -42,7 +42,8 @@ export class PenguinJudgeContestSubmission extends LitElement {
     if (!this.submission) {
       return;
     }
-    const tests = this.submission.tests.map(
+    this.submission.tests = [{ "memory": 4, "status": JudgeStatus.Accepted, "time": 0.005163, "id": "1" }];
+    const tests = this.submission!.tests.map(
       t => html`
         <tr>
           <td>${t.id}</td>
@@ -54,16 +55,16 @@ export class PenguinJudgeContestSubmission extends LitElement {
 
     return html`
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/default.min.css" />
-      <h2>提出: #${this.submission.id}</h2>
+      <h2>提出: #${this.submission!.id}</h2>
       <h3>ソースコード</h3>
-      <pre><code>${unsafeHTML(hljs.highlightAuto(this.submission.code).value)}</code></pre>
+      <pre><code>${unsafeHTML(hljs.highlightAuto(this.submission!.code).value)}</code></pre>
       <h3>提出情報</h3>
       <table>
-        <tr><th>提出日時</th><td>${format_datetime_detail(this.submission.created)}</td></tr>
-        <tr><th>問題</th><td>${this.submission.problem_id}</td></tr>
+        <tr><th>提出日時</th><td>${format_datetime_detail(this.submission!.created)}</td></tr>
+        <tr><th>問題</th><td><a is="router_link" href="${router.generate('contest-task', { id: session.contest!.id, task_id: this.submission.problem_id })}">${this.submission.problem_id}</a></td></tr>
         <tr><th>ユーザ</th><td>${this.submission.user_id}</td></tr>
         <tr><th>言語</th><td>${session.environment_mapping[this.submission.environment_id].name}</td></tr>
-        <tr><th>結果</th><td>${getSubmittionStatusMark(this.submission.status)}${this.submission.status}</td></tr>
+        <tr><th>結果</th><td>${getSubmittionStatusMark(this.submission!.status)}${this.submission.status}</td></tr>
       </table>
       <h3>テストケース</h3>
       <table class="testcase">


### PR DESCRIPTION
- サーバ側で提出一覧は全部ではなくページ毎に返ってきている
- 提出の情報は順位情報より大きいのでページネーションが必要
- フロントエンド側でページネーションに暫定対応
  - レスポンスヘッダで全ページ数は返ってくるが現状触りづらいため
  - 無限に後ろのページに行くことができる