### PR TITLE
Use pushed images on docker-compose up --no-build

### DIFF
--- a/container/pull.sh
+++ b/container/pull.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+docker pull penguinjudge/agent_go_compile:1.13.4
+docker tag penguinjudge/agent_go_compile:1.13.4 penguin_judge_go_compile:1.13.4
+docker pull penguinjudge/agent_go_judge:1.13.4
+docker tag penguinjudge/agent_go_judge:1.13.4 penguin_judge_go_judge:1.13.4
+docker pull penguinjudge/agent_python_judge:3.7
+docker tag penguinjudge/agent_python_judge:3.7 penguin_judge_python:3.7
+docker pull penguinjudge/agent_rust_compile:1.39.0
+docker tag penguinjudge/agent_rust_compile:1.39.0 penguin_judge_rust_compile:1.39.0
+docker pull penguinjudge/agent_rust_judge:1.39.0
+docker tag penguinjudge/agent_rust_judge:1.39.0 penguin_judge_rust_judge:1.39.0
+docker pull penguinjudge/agent_java_compile:14
+docker tag penguinjudge/agent_java_compile:14 penguin_judge_java_compile:14
+docker pull penguinjudge/agent_java_judge:14
+docker tag penguinjudge/agent_java_judge:14 penguin_judge_java_judge:14
+docker pull penguinjudge/agent_pypy3.6_judge:7.2
+docker tag penguinjudge/agent_pypy3.6_judge:7.2 penguin_judge_pypy3.6:7.2.0
+docker pull penguinjudge/agent_cpp_compile:8.2
+docker tag penguinjudge/agent_cpp_compile:8.2 penguin_judge_cpp_compile:8.2
+docker pull penguinjudge/agent_cpp_judge:8.2
+docker tag penguinjudge/agent_cpp_judge:8.2 penguin_judge_cpp_judge:8.2
+docker pull penguinjudge/agent_node_judge:12.13.0
+docker tag penguinjudge/agent_node_judge:12.13.0 penguin_judge_node:12.13.0
+docker pull penguinjudge/agent_c_compile:8.2
+docker tag penguinjudge/agent_c_compile:8.2 penguin_judge_c_compile:8.2
+docker pull penguinjudge/agent_c_judge:8.2
+docker tag penguinjudge/agent_c_judge:8.2 penguin_judge_c_judge:8.2
+docker pull penguinjudge/agent_ruby_judge:2.6.5
+docker tag penguinjudge/agent_ruby_judge:2.6.5 penguin_judge_ruby:2.6.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   api:
+    image: penguinjudge/backend
     build: backend/
     ports:
       - 5000:5000
@@ -12,6 +13,7 @@ services:
       - mq
       - db
   worker:
+    image: penguinjudge/backend
     build: backend/
     volumes:
       - ./.docker-compose:/mnt:ro
@@ -20,7 +22,9 @@ services:
     depends_on:
       - mq
       - db
+      - puller
   gui:
+    image: penguinjudge/frontend
     build: frontend
     depends_on:
       - api
@@ -32,3 +36,9 @@ services:
     image: postgres:alpine
     environment:
       POSTGRES_PASSWORD: password
+  puller:
+    image: docker
+    volumes:
+      - ./container:/mnt:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: /bin/sh -c "/mnt/pull.sh && while true; do sleep 86400; done"

--- a/tools/register_environments.py
+++ b/tools/register_environments.py
@@ -11,15 +11,15 @@ class Environment(NamedTuple):
 
 
 ENVIRONMENTS = [
-    Environment('C (gcc 8.2)', 'penguin_judge_c_judge:8.2', 'penguin_judge_c_compile:8.2'),
-    Environment('C++ (gcc 8.2)', 'penguin_judge_cpp_judge:8.2', 'penguin_judge_cpp_compile:8.2'),
-    Environment('Python (3.7)', 'penguin_judge_python:3.7', None),
-    Environment('PyPy3.6 (7.2.0)', 'penguin_judge_pypy3.6:7.2.0', None),
-    Environment('Ruby (2.6.5)', 'penguin_judge_ruby:2.6.5', None),
-    Environment('Go (1.13.4)', 'penguin_judge_go_judge:1.13.4', 'penguin_judge_go_compile:1.13.4'),
-    Environment('Java (OpenJDK 14)', 'penguin_judge_java_judge:14', 'penguin_judge_java_compile:14'),
-    Environment('Node (12.13.0)', 'penguin_judge_node:12.13.0', None),
-    Environment('Rust (1.39.0)', 'penguin_judge_rust_judge:1.39.0', 'penguin_judge_rust_compile:1.39.0'),
+    Environment('C (gcc 8.2)', 'penguinjudge/agent_c_judge:8.2', 'penguinjudge/agent_c_compile:8.2'),
+    Environment('C++ (gcc 8.2)', 'penguinjudge/agent_cpp_judge:8.2', 'penguinjudge/agent_cpp_compile:8.2'),
+    Environment('Python (3.7)', 'penguinjudge/agent_python_judge:3.7', None),
+    Environment('PyPy3.6 (7.2)', 'penguinjudge/agent_pypy3.6_judge:7.2', None),
+    Environment('Ruby (2.6.5)', 'penguinjudge/agent_ruby_judge:2.6.5', None),
+    Environment('Go (1.13.4)', 'penguinjudge/agent_go_judge:1.13.4', 'penguinjudge/agent_go_compile:1.13.4'),
+    Environment('Java (OpenJDK 14)', 'penguinjudge/agent_java_judge:14', 'penguinjudge/agent_java_compile:14'),
+    Environment('Node (12.13.0)', 'penguinjudge/agent_node_judge:12.13.0', None),
+    Environment('Rust (1.39.0)', 'penguinjudge/agent_rust_judge:1.39.0', 'penguinjudge/agent_rust_compile:1.39.0'),
 ]
 
 items = {}


### PR DESCRIPTION
docker-compose で気軽に動作確認できるようにした
* imageをビルドせず hub.docker.com から `docker-compose pull` できるよう `image` を追加
* `docker-compose pull` では pull されないジャッジイメージを自動で pull するための `puller` コンテナを追加
* ジャッジイメージのDB登録スクリプトのイメージ名を puller で pull した版を利用できるよう、最新化